### PR TITLE
Switch to source content, add NS2.0 support

### DIFF
--- a/src/JQ/JQ.csproj
+++ b/src/JQ/JQ.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <PackageId>Devlooped.JQ</PackageId>
     <Description>A .NET-friendly distribution of the official JQ implementation</Description>
     <PackNone>true</PackNone>
     <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);**/.gitignore</DefaultExcludesInProjectFolder>
+    <PackCompile>true</PackCompile>
+    <PackBuildOutput>false</PackBuildOutput>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Rather than a runtime binary dependency containing just one class, make it a source file included via the package instead. The transitive targets should take care of bringing the runtime assets anyway when consumed from an app, so this shouldn't change anything.