### PR TITLE
Hide JQ.cs from explorer by default

### DIFF
--- a/src/JQ/buildTransitive/Devlooped.JQ.props
+++ b/src/JQ/buildTransitive/Devlooped.JQ.props
@@ -5,6 +5,9 @@
              Link="lib/%(Filename)%(Extension)"
              Visible="false"
              CopyToOutputDirectory="PreserveNewest" />
+
+    <!-- Hide the source JQ.cs from explorer by default -->  
+    <Compile Update="@(Compile -> WithMetadataValue('NuGetPackageId', 'Devlooped.JQ'))" Visible="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Users can see it by turning on Show All Files.