### PR TITLE
Don't force the type to be public

### DIFF
--- a/src/JQ/JQ.cs
+++ b/src/JQ/JQ.cs
@@ -17,7 +17,7 @@ namespace Devlooped;
 /// <remarks>
 /// Learn more about JQ at https://jqlang.github.io/jq/.
 /// </remarks>
-public static partial class JQ
+static partial class JQ
 {
     static readonly object syncLock = new();
     static readonly string jqpath;

--- a/src/JQ/JQ.csproj
+++ b/src/JQ/JQ.csproj
@@ -22,4 +22,8 @@
     <Exec Command="gh release download --dir tools --clobber -p jq-windows-* --repo jqlang/jq" />
   </Target>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Tests"/>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Now that we're being included as source, we should not make our type part of the public API surface of a consuming project.